### PR TITLE
CI: add test coverage workflow (covr) with HTML artifact

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,0 +1,22 @@
+name: test-coverage
+on:
+  pull_request:
+  push: { branches: [ master, main ] }
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::covr
+      - name: Run coverage
+        run: |
+          Rscript -e "cov <- covr::package_coverage()"
+          Rscript -e "covr::report(cov, file = "coverage.html")"
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: coverage.html

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -17,10 +17,8 @@ jobs:
             any::covr
             any::DT
             any::htmltools
-      - name: Run coverage
-        run: |
-          Rscript -e 'cov <- covr::package_coverage()'
-          Rscript -e 'covr::report(cov, file = "coverage.html")'
+      - name: Run coverage and save report
+        run: Rscript -e 'cov <- covr::package_coverage(); covr::report(cov, file = "coverage.html")'
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,3 +1,4 @@
+
 name: test-coverage
 on:
   pull_request:
@@ -12,13 +13,17 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr
+          extra-packages: |
+            any::covr
+            any::DT
+            any::htmltools
       - name: Run coverage
         run: |
-          Rscript -e "cov <- covr::package_coverage()"
-          Rscript -e "covr::report(cov, file = 'coverage.html')"
+          Rscript -e 'cov <- covr::package_coverage()'
+          Rscript -e 'covr::report(cov, file = "coverage.html")'
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:
           name: coverage-html
           path: coverage.html
+

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,7 +1,9 @@
 name: test-coverage
 on:
   pull_request:
-  push: { branches: [ master, main ] }
+  push:
+    branches: [ master, main ]
+
 jobs:
   coverage:
     runs-on: ubuntu-latest
@@ -14,7 +16,7 @@ jobs:
       - name: Run coverage
         run: |
           Rscript -e "cov <- covr::package_coverage()"
-          Rscript -e "covr::report(cov, file = "coverage.html")"
+          Rscript -e "covr::report(cov, file = 'coverage.html')"
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,3 +13,6 @@ Imports:
     tibble
 URL: https://github.com/raghavanvishnu/tinyvalid
 BugReports: https://github.com/raghavanvishnu/tinyvalid/issues
+Suggests: 
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,10 @@
-# tests/testthat.R
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
 
 library(testthat)
 library(tinyvalid)


### PR DESCRIPTION
**What**
- Adds .github/workflows/test-coverage.yaml.
- Runs covr::package_coverage() on Ubuntu for pushes/PRs to master/main.
- Uploads coverage.html as an artifact (no external services).

**Why**
- See test coverage per commit/PR without Codecov.

**How to view**
- PR -> Actions -> "test-coverage" run -> Artifacts -> download coverage-html -> open coverage.html.

**Scope**
- CI-only change. No package code changed.
